### PR TITLE
Tag the agent with its system architecture

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -36,7 +36,7 @@
 
   services.buildkite-agent = {
     enable = true;
-    meta-data = "mac=1";
+    meta-data = "mac=1,system=${pkgs.system}";
     openssh.privateKeyPath = "/dev/null";
     openssh.publicKeyPath = "/dev/null";
     tokenPath = "/nix/home/buildkite.token";


### PR DESCRIPTION
This will allow us to choose between any specific architecture machine we have, rather than allowing it to give us a roulette of which architecture we'll run.

---

~~Drafted because this option shouldn't exist past 20.03, according to https://github.com/NixOS/nixpkgs/blob/b463da9989064740182841992f70a670601e415c/nixos/doc/manual/from_md/release-notes/rl-2003.section.xml#L883-L887 (and there is no other reference to `meta-data` in nixpkgs, that I could find).~~ Well duh, it's using nix-darwin: https://daiderd.com/nix-darwin/manual/index.html#opt-services.buildkite-agent.meta-data.