### PR TITLE
bootstrap nodes: erase the machine after each job

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -43,6 +43,7 @@
     tokenPath = "/nix/home/buildkite.token";
     extraConfig = ''
       spawn = 4
+      tags-from-host=true
     '';
   };
   system.activationScripts.pam.text = ''

--- a/setup-without-nix.sh
+++ b/setup-without-nix.sh
@@ -101,6 +101,7 @@ disconnect-after-job=true
 meta-data="queue=bootstrap,mac=1,nix=0,system=$arch"
 build-path="/var/lib/buildkite-agent/builds"
 hooks-path="/var/lib/buildkite-agent/hooks"
+tags-from-host=true
 EOF
 
     cp /Volumes/CONFIG/buildkite-agent/sshkey ~ephemeraladmin/.ssh/id_ed25519

--- a/setup-without-nix.sh
+++ b/setup-without-nix.sh
@@ -115,7 +115,12 @@ EOF
     cat <<EOF > /var/lib/buildkite-agent/hooks/agent-shutdown
 #!/bin/sh
 
-curl -v http://bonk
+while sleep 1; do
+    for machine in bonk{,-{1,2,3,4,5}}; do
+        curl --connect-timeout 1 -v "http://$machine"
+	sleep 1
+    done
+done
 EOF
     chmod +x /var/lib/buildkite-agent/hooks/agent-shutdown
 

--- a/setup-without-nix.sh
+++ b/setup-without-nix.sh
@@ -112,7 +112,7 @@ EOF
       ~ephemeraladmin/.ssh/id_ed25519.pub
 
     mkdir -p /var/lib/buildkite-agent/hooks
-    cat <<EOF > /var/lib/buildkite-agent/hooks/agent-shutdown
+    cat <<'EOF' > /var/lib/buildkite-agent/hooks/agent-shutdown
 #!/bin/sh
 
 while sleep 1; do

--- a/setup-without-nix.sh
+++ b/setup-without-nix.sh
@@ -96,8 +96,9 @@ EOF
     cat <<EOF > /var/lib/buildkite-agent/buildkite-agent.cfg
 token="$(cat /Volumes/CONFIG/buildkite.token)"
 name="%hostname-%n"
-spawn=4
-meta-data="mac=1,nix=0,system=$arch"
+spawn=1
+disconnect-after-job=true
+meta-data="queue=bootstrap,mac=1,nix=0,system=$arch"
 build-path="/var/lib/buildkite-agent/builds"
 hooks-path="/var/lib/buildkite-agent/hooks"
 EOF
@@ -108,6 +109,14 @@ EOF
     chown ephemeraladmin:staff \
       ~ephemeraladmin/.ssh/id_ed25519 \
       ~ephemeraladmin/.ssh/id_ed25519.pub
+
+    mkdir -p /var/lib/buildkite-agent/hooks
+    cat <<EOF > /var/lib/buildkite-agent/hooks/agent-shutdown
+#!/bin/sh
+
+curl -v http://bonk
+EOF
+    chmod +x /var/lib/buildkite-agent/hooks/agent-shutdown
 
     chown -R ephemeraladmin:staff /var/lib/buildkite-agent
 


### PR DESCRIPTION
We want to guarantee that each Nix install starts
from a relatively fresh environment. By setting
the machine to take one job at a time and erase,
we pretty much get that.

Note the "bonk" integration isn't super good, but
its a start.