### PR TITLE
Accept routes from tailscale

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -116,7 +116,7 @@
       set -eux
 
       sleep 5
-      ${pkgs.tailscale}/bin/tailscale up --auth-key file:/nix/home/tailscale.token
+      ${pkgs.tailscale}/bin/tailscale up --accept-routes --auth-key file:/nix/home/tailscale.token
       while true; do
         sleep 604800
       done

--- a/setup-without-nix.sh
+++ b/setup-without-nix.sh
@@ -105,7 +105,7 @@ EOF
   <array>
     <string>/bin/sh</string>
     <string>-c</string>
-    <string>sleep 5 ; /usr/local/bin/tailscale up --auth-key file:/var/root/tailscale.token && (while true; do sleep 2073600; done)</string>
+    <string>sleep 5 ; /usr/local/bin/tailscale up --accept-routes --auth-key file:/var/root/tailscale.token && (while true; do sleep 2073600; done)</string>
   </array>
 
   <key>RunAtLoad</key>


### PR DESCRIPTION
Gonna do this after https://github.com/DeterminateSystems/macos-ephemeral/pull/12, since it also touches the `tailscale up` stuff for the non-nix macs.